### PR TITLE
Potential fix for code scanning alert no. 6: Uncontrolled data used in path expression

### DIFF
--- a/ml/main.py
+++ b/ml/main.py
@@ -30,7 +30,9 @@ def process(payload: dict):
     minio_object = payload.get("minio_object")
     record_id = payload.get("record_id")
 
-    ext = minio_object.rsplit(".", 1)[-1]
+    ext = str(minio_object).rsplit(".", 1)[-1].lower()
+    if not (1 <= len(ext) <= 10 and ext.isalnum()):
+        ext = "bin"
     with tempfile.NamedTemporaryFile(suffix=f".{ext}", delete=False) as tmp:
         tmp_path = tmp.name
 


### PR DESCRIPTION
Potential fix for [https://github.com/Santhosh-p653/deepfake-agentic-ai/security/code-scanning/6](https://github.com/Santhosh-p653/deepfake-agentic-ai/security/code-scanning/6)

The safest fix is to stop using raw user-derived extension text in temporary filename construction. Instead, sanitize `ext` to a strict allowlist format (for example alphanumeric only, lowercase, length-limited), and fall back to a safe default if invalid.

Best concrete fix in `ml/main.py`:
- In `process`, after extracting `ext`, normalize and validate it:
  - `ext = ext.lower()`
  - allow only `[a-z0-9]` and a reasonable length (e.g., 1..10)
  - if invalid, set `ext = "bin"`
- Continue using `NamedTemporaryFile` with `suffix=f".{ext}"`.

This preserves functionality (temp file still has an extension) while removing attacker-controlled path characters. No new dependencies are needed; built-in string checks are sufficient.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
