### PR TITLE
Potential fix for code scanning alert no. 6: Uncontrolled data used in path expression

### DIFF
--- a/ml/main.py
+++ b/ml/main.py
@@ -30,10 +30,7 @@ def process(payload: dict):
     minio_object = payload.get("minio_object")
     record_id = payload.get("record_id")
 
-    ext = str(minio_object).rsplit(".", 1)[-1].lower()
-    if not (1 <= len(ext) <= 10 and ext.isalnum()):
-        ext = "bin"
-    with tempfile.NamedTemporaryFile(suffix=f".{ext}", delete=False) as tmp:
+    with tempfile.NamedTemporaryFile(suffix=".bin", delete=False) as tmp:
         tmp_path = tmp.name
 
     try:


### PR DESCRIPTION
Potential fix for [https://github.com/Santhosh-p653/deepfake-agentic-ai/security/code-scanning/6](https://github.com/Santhosh-p653/deepfake-agentic-ai/security/code-scanning/6)

To fix this safely and without changing core functionality, remove user influence from the temp file suffix entirely.

Best single fix in `ml/main.py`:
- In `process`, delete the logic that extracts/validates `ext` from `minio_object`.
- Use a constant suffix (for example `.bin`) when creating the temp file.

This preserves behavior (temporary file still created and processed the same way) while eliminating tainted data flow into the path expression sink.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
